### PR TITLE
Fix build error

### DIFF
--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -19,7 +19,7 @@ pub struct Error {
 }
 
 #[deriving(Show, Eq, Clone)]
-enum BencodePosition {
+pub enum BencodePosition {
     ListPosition,
     KeyPosition,
     ValuePosition


### PR DESCRIPTION
Using rust 0.10, "make" was failing with this output:

```
mkdir -p build
mkdir -p build/test
rustc --test -o build/test/test src/bencode.rs
src/streaming.rs:34:16: 34:31 error: private type in exported type signature, #[deny(visible_private_types)] on by default
src/streaming.rs:34     stack: Vec<BencodePosition>,
                                   ^~~~~~~~~~~~~~~
error: aborting due to previous error
make: *** [libtest] Error 101
```
