### PR TITLE
Allow `Key` to be constructed manually

### DIFF
--- a/src/bencode.rs
+++ b/src/bencode.rs
@@ -243,7 +243,7 @@ impl fmt::Show for Bencode {
 }
 
 #[deriving(Eq, PartialEq, Clone, Ord, PartialOrd, Show, Hash)]
-pub struct Key(Vec<u8>);
+pub struct Key(pub Vec<u8>);
 
 pub type List = Vec<Bencode>;
 pub type Dict = TreeMap<Key, Bencode>;


### PR DESCRIPTION
Tuple structs are now allowed to have private fields which means
you can not manually construct a Key with the old syntax.

This is annoying because scrape responses use the info-hash as dictionary keys.
