### PR TITLE
Make travis happy again by fixing Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ name = "bencode"
 version = "0.1.0"
 authors = ["arjan.top@gmail.com"]
 
-[lib]
+[[lib]]
 
 name = "bencode"


### PR DESCRIPTION
'lib' in Cargo.toml is expected to be an array [[lib]], not table
[lib](thanks for Toml developer for 'obvious' format).

Both variants pass locally but for mysterious reasons table one
fails on Travis.

Successful build: https://travis-ci.org/Divius/rust-bencode
