### PR TITLE
Show utf8 bytestrings as strings

### DIFF
--- a/src/bencode.rs
+++ b/src/bencode.rs
@@ -213,6 +213,14 @@ use streaming::{BencodeEvent, NumberValue, ByteStringValue, ListStart,
 pub mod streaming;
 pub mod util;
 
+#[inline]
+fn fmt_bytestring(s: &[u8], fmt: &mut fmt::Formatter) -> fmt::Result {
+  match str::from_utf8(s) {
+    Some(s) => write!(fmt, "s\"{}\"", s),
+    None    => write!(fmt, "s{}", s),
+  }
+}
+
 #[deriving(PartialEq, Clone)]
 pub enum Bencode {
     Empty,
@@ -227,10 +235,7 @@ impl fmt::Show for Bencode {
         match self {
             &Bencode::Empty => { Ok(()) }
             &Bencode::Number(v) => write!(fmt, "{}", v),
-            &Bencode::ByteString(ref v) => match str::from_utf8(v.as_slice()) {
-                Some(s) => write!(fmt, "s\"{}\"", s),
-                None    => write!(fmt, "s{}", v),
-            },
+            &Bencode::ByteString(ref v) => fmt_bytestring(v.as_slice(), fmt),
             &Bencode::List(ref v) => write!(fmt, "{}", v),
             &Bencode::Dict(ref v) => {
                 try!(write!(fmt, "{{"));

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,4 @@
 use std::str::raw;
-use std::str;
 use std::fmt;
 
 use serialize;
@@ -35,11 +34,9 @@ impl ByteString {
 
 impl fmt::Show for ByteString {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use fmt_bytestring;
         match self {
-            &ByteString(ref v) => match str::from_utf8(v.as_slice()) {
-                Some(s) => write!(fmt, "s\"{}\"", s),
-                None    => write!(fmt, "s{}", v),
-            }
+            &ByteString(ref v) => fmt_bytestring(v.as_slice(), fmt),
         }
     }
 }


### PR DESCRIPTION
This changes the implementation of `Show` for `util::ByteString` and `Bencode::ByteString` so that when they contain valid utf8 they are shown as strings. ie. `s"foo"` instead of `s[102, 111, 111]`.
