### PR TITLE
Add richer error handling to FromBencode trait.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ name = "bencode"
 [dependencies]
 
 rustc-serialize = "~0.3.0"
+byteorder = "*"
+num = "*"
+

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 use std::{str, fmt};
+use std::borrow::Borrow;
 
 use rustc_serialize as serialize;
 use rustc_serialize::Encodable;
@@ -44,6 +45,14 @@ impl Encodable for ByteString {
     fn encode<S: serialize::Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
         let &ByteString(ref key) = self;
         e.emit_str(unsafe { str::from_utf8_unchecked(&key[..]) })
+    }
+}
+
+impl Borrow<[u8]> for ByteString {
+    fn borrow(&self) -> &[u8] {
+        match self {
+            &ByteString(ref v)  => v.borrow()
+        }
     }
 }
 


### PR DESCRIPTION
This  changes the definition of `FromBecode` to 

    trait FromBencode {
        type Err;
        fn from_bencode(bencode: &Bencode) -> Result<Self, Self::Err>;
    }

allowing the `from_bencode` methods to say why they weren't able to convert from bencode. It also adds error types for the various different `FromBencode` implementations.